### PR TITLE
fix: schedule error in cron job

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,6 @@
   ],
   "crons": [{
     "path": "/api/cron",
-    "schedule": "0 11 * 4 *"
+    "schedule": "0 11 * * 4"
   }]
 }


### PR DESCRIPTION
Fixed schedule error where the cron job expression was entered incorrectly

It will now run every day at 1100am like it was intended. 